### PR TITLE
Add communication devices to export

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ The following items are exported:
 - Properties
 - Actions
 - Transitions
+- Communication Devices\*
+
+\*see [Exporting and Importing Communication Devices](#exporting-and-importing-communication-devices)
 
 Items are exported in formatted structured text (`.st`) where possible, and in native CODESYS xml everywhere else.
 
@@ -47,6 +50,12 @@ _Note, it is recommended to not source control the actual working copy of the pr
 A template file can be generated from an existing project file by using the `Save As Template` script. This script will copy the project, give it the appropriate name and delete any objects that can be imported by CODESCRIBE. If an existing project following the template naming scheme is found, the new template will use an incremented version number.
 
 To generate a project from a template file, you need two things: the `<project_name>_template_v<X>.project` file and a folder named `<project_name>` with the files exported by the `Export To Files` script. To generate a project, copy the template project in the same location and rename it to `<project_name>.project`. Open the copy with CODESYS and use the `Import From Files` button to import the project files.
+
+## Exporting and Importing Communication Devices
+
+Exporting communication devices has been hardcoded to create folders for top-level devices under `Communication`. Any devices under these top-level devices will be exported using native CODESYS xml. This is done because the top-level devices can not be removed from the CODESYS project.
+
+**If this functionality is causing you problems, it can be disabled by adding a folder with the name `_NO_EXPORT` directly under `Communication`.** You can then still rely on your project template to carry your communication configurations.
 
 ## Status
 

--- a/src/communication_import_export.py
+++ b/src/communication_import_export.py
@@ -1,0 +1,21 @@
+import os
+
+from object_type import ObjectType
+from util import *
+
+
+def export_communication(communication_obj, communication_folder_path):
+    """
+    Export communication is hardcoded to create folders for the top level devices inside the communication object, and
+    then do a native recursive export for any devices under those top level devices.
+    """
+    if first_of_type_or_none(communication_obj.find("_NO_EXPORT"), ObjectType.FOLDER) is not None:
+        return
+
+    for top_level_device in communication_obj.get_children():
+        top_level_device_folder = os.path.join(communication_folder_path, top_level_device.get_name())
+        os.mkdir(top_level_device_folder)
+        for child_device in top_level_device.get_children():
+            child_device.export_native(
+                os.path.join(top_level_device_folder, child_device.get_name() + ".xml"), recursive=True
+            )

--- a/src/communication_import_export.py
+++ b/src/communication_import_export.py
@@ -4,7 +4,7 @@ from object_type import ObjectType
 from util import *
 
 
-def export_communication(communication_obj, communication_folder_path):
+def export_communication(communication_obj, device_folder):
     """
     Export communication is hardcoded to create folders for the top level devices inside the communication object, and
     then do a native recursive export for any devices under those top level devices.
@@ -12,8 +12,11 @@ def export_communication(communication_obj, communication_folder_path):
     if first_of_type_or_none(communication_obj.find("_NO_EXPORT"), ObjectType.FOLDER) is not None:
         return
 
+    communication_folder = os.path.join(device_folder, "communication")
+    os.mkdir(communication_folder)
+
     for top_level_device in communication_obj.get_children():
-        top_level_device_folder = os.path.join(communication_folder_path, top_level_device.get_name())
+        top_level_device_folder = os.path.join(communication_folder, top_level_device.get_name())
         os.mkdir(top_level_device_folder)
         for child_device in top_level_device.get_children():
             child_device.export_native(

--- a/src/communication_import_export.py
+++ b/src/communication_import_export.py
@@ -22,3 +22,28 @@ def export_communication(communication_obj, device_folder):
             child_device.export_native(
                 os.path.join(top_level_device_folder, child_device.get_name() + ".xml"), recursive=True
             )
+
+
+def import_communication(communication_obj, device_folder):
+    communication_folder = os.path.join(device_folder, "communication")
+    if not os.path.exists(communication_folder):
+        return
+
+    # remove all children from top level devices
+    for top_level_device in communication_obj.get_children():
+        for child in top_level_device.get_children():
+            child.remove()
+
+    # for top level folders inside the communcation folder, do a native import on the corresponding communication device
+    for name in os.listdir(communication_folder):
+        full_path = os.path.join(communication_folder, name)
+        if not os.path.isdir(full_path):
+            continue
+
+        top_level_device = first_of_type_or_error(
+            communication_obj.find(name), ObjectType.DEVICE, "Cannot find communication device with name " + name
+        )
+        for child_name in os.listdir(full_path):
+            _, ext = os.path.splitext(child_name)
+            if ext == ".xml":
+                top_level_device.import_native(os.path.join(full_path, child_name))

--- a/src/entrypoint.py
+++ b/src/entrypoint.py
@@ -28,3 +28,10 @@ def find_application(device_obj):
         device_obj.find("Application", recursive=True),
         "Couldn't find Application inside " + device_obj.get_name(),
     )
+
+
+def find_communication(device_obj):
+    return first_or_error(
+        device_obj.find("Communication", recursive=True),
+        "Couldn't find Communication inside " + device_obj.get_name(),
+    )

--- a/src/import_from_files.py
+++ b/src/import_from_files.py
@@ -57,6 +57,8 @@ def import_from_files(project):
         assert_path_exists(device_folder)
 
         application = find_application(device_obj)
+        application_folder = os.path.join(device_folder, "application")
+
         remove_tracked_objects(application.get_children())
 
-        import_directory(device_folder, application)
+        import_directory(application_folder, application)

--- a/src/import_from_files.py
+++ b/src/import_from_files.py
@@ -1,5 +1,6 @@
 import os
 
+from communication_import_export import import_communication
 from entrypoint import find_application, find_communication, get_device_entrypoints, get_src_folder
 from import_export import *
 from util import *
@@ -60,3 +61,6 @@ def import_from_files(project):
         application_folder = os.path.join(device_folder, "application")
         remove_tracked_objects(application.get_children())
         import_directory(application_folder, application)
+
+        communication = find_communication(device_obj)
+        import_communication(communication, device_folder)

--- a/src/import_from_files.py
+++ b/src/import_from_files.py
@@ -1,6 +1,6 @@
 import os
 
-from entrypoint import find_application, get_device_entrypoints, get_src_folder
+from entrypoint import find_application, find_communication, get_device_entrypoints, get_src_folder
 from import_export import *
 from util import *
 
@@ -58,7 +58,5 @@ def import_from_files(project):
 
         application = find_application(device_obj)
         application_folder = os.path.join(device_folder, "application")
-
         remove_tracked_objects(application.get_children())
-
         import_directory(application_folder, application)

--- a/src/script_export_to_files.py
+++ b/src/script_export_to_files.py
@@ -42,8 +42,6 @@ for device_obj in get_device_entrypoints(scriptengine.projects.primary):
         export_child(child_obj, application, application_folder)
 
     communication = find_communication(device_obj)
-    communication_folder = os.path.join(device_folder, "communication")
-    os.mkdir(communication_folder)
-    export_communication(communication, communication_folder)
+    export_communication(communication, device_folder)
 
 print("Done!")

--- a/src/script_export_to_files.py
+++ b/src/script_export_to_files.py
@@ -6,7 +6,8 @@ import shutil
 
 import scriptengine  # type: ignore
 
-from entrypoint import find_application, get_device_entrypoints, get_src_folder
+from communication_import_export import export_communication
+from entrypoint import find_application, find_communication, get_device_entrypoints, get_src_folder
 from import_export import OBJECT_TYPE_TO_EXPORT_FUNCTION
 from object_type import get_object_type
 from util import *
@@ -39,5 +40,10 @@ for device_obj in get_device_entrypoints(scriptengine.projects.primary):
 
     for child_obj in application.get_children():
         export_child(child_obj, application, application_folder)
+
+    communication = find_communication(device_obj)
+    communication_folder = os.path.join(device_folder, "communication")
+    os.mkdir(communication_folder)
+    export_communication(communication, communication_folder)
 
 print("Done!")

--- a/src/script_export_to_files.py
+++ b/src/script_export_to_files.py
@@ -12,11 +12,11 @@ from object_type import get_object_type
 from util import *
 
 
-def export_application_child(child_obj, parent_obj, parent_folder_path):
+def export_child(child_obj, parent_obj, parent_folder_path):
     child_obj_type = get_object_type(child_obj)
     export_fn = OBJECT_TYPE_TO_EXPORT_FUNCTION.get(child_obj_type)
     if export_fn is not None:
-        export_fn(child_obj, parent_obj, parent_folder_path, export_application_child)
+        export_fn(child_obj, parent_obj, parent_folder_path, export_child)
 
 
 print_python_version()
@@ -34,8 +34,10 @@ for device_obj in get_device_entrypoints(scriptengine.projects.primary):
     os.mkdir(device_folder)
 
     application = find_application(device_obj)
+    application_folder = os.path.join(device_folder, "application")
+    os.mkdir(application_folder)
 
     for child_obj in application.get_children():
-        export_application_child(child_obj, application, device_folder)
+        export_child(child_obj, application, application_folder)
 
 print("Done!")

--- a/src/script_save_as_template.py
+++ b/src/script_save_as_template.py
@@ -6,7 +6,8 @@ import shutil
 
 import scriptengine  # type: ignore
 
-from entrypoint import find_application, get_device_entrypoints
+from communication_import_export import remove_tracked_communication_devices
+from entrypoint import find_application, find_communication, get_device_entrypoints
 from import_export import *
 from project_template import find_template_paths_and_versions, generate_template_path
 from util import *
@@ -47,6 +48,8 @@ template_project = scriptengine.projects.get_by_path(new_template_path)
 for device_obj in get_device_entrypoints(template_project):
     application = find_application(device_obj)
     remove_tracked_objects(application.get_children())
+    communication = find_communication(device_obj)
+    remove_tracked_communication_devices(communication)
 
 template_project.save()
 

--- a/src/util.py
+++ b/src/util.py
@@ -32,6 +32,13 @@ def first_of_type_or_error(lst, obj_type, err):
     raise ValueError(err)
 
 
+def first_of_type_or_none(lst, obj_type):
+    for obj in lst:
+        if get_object_type(obj) == obj_type:
+            return obj
+    return None
+
+
 def first_or_error(lst, err):
     try:
         return next(iter(lst))


### PR DESCRIPTION
Copied from readme:

Exporting communication devices has been hardcoded to create folders for top-level devices under `Communication`. Any devices under these top-level devices will be exported using native CODESYS xml. This is done because the top-level devices can not be removed from the CODESYS project.

**If this functionality is causing you problems, it can be disabled by adding a folder with the name `_NO_EXPORT` directly under `Communication`.** You can then still rely on your project template to carry your communication configurations.
