### PR TITLE
export gvl files as st with an xml sidecar

### DIFF
--- a/src/import_from_files.py
+++ b/src/import_from_files.py
@@ -27,7 +27,13 @@ def import_directory_child(child, dir_path, dir_parent_obj):
     if os.path.isdir(full_path):
         import_folder(child, dir_path, dir_parent_obj, import_directory)
 
-    if "." in filename:
+    if filename.endswith(".gvl"):
+        if ext == ".xml":
+            # this is just here to point out that the xml is imported alongside the st file
+            pass
+        if ext == ".st":
+            import_gvl(child, dir_path, dir_parent_obj, import_directory)
+    elif "." in filename:
         # . means some sort of sub POU
         if ext == ".xml":
             import_sub_pou(child, dir_path, dir_parent_obj, import_directory)

--- a/src/object_type.py
+++ b/src/object_type.py
@@ -5,7 +5,7 @@ import inspect
 class ObjectType:
     POU = "POU"
     DUT = "DUT"
-    EVL = "EVL"
+    GVL = "EVL"
     EVC = "EVC"
     METHOD = "METHOD"
     PROPERTY = "PROPERTY"
@@ -31,7 +31,7 @@ class ObjectType:
 GUID_TYPE_MAPPING = {
     "6f9dac99-8de1-4efc-8465-68ac443b7d08": ObjectType.POU,
     "2db5746d-d284-4425-9f7f-2663a34b0ebc": ObjectType.DUT,
-    "ffbfa93a-b94d-45fc-a329-229860183b1d": ObjectType.EVL,
+    "ffbfa93a-b94d-45fc-a329-229860183b1d": ObjectType.GVL,
     "327b6465-4e7f-4116-846a-8369c730fd66": ObjectType.EVC,
     "f8a58466-d7f6-439f-bbb8-d4600e41d099": ObjectType.METHOD,
     "5a3b8626-d3e9-4f37-98b5-66420063d91e": ObjectType.PROPERTY,


### PR DESCRIPTION
GVL files are now exported as a structured text file (containing their declaration) and a native XML export (containing any other codesys configuration).

For example, a GVL called `GLOBALS` will be exported as two files: `GLOBALS.gvl.xml` and `GLOBALS.gvl.st`.

The XML export is necessary because network variable lists and exchange variable lists are implemented as GVLs under the hood, so we if exported all GVLs as st only, we would loose their configuration.

NOTE: the XML export does contain the variable definitions, as well as the st file. This can lead to inconsistency when the st file is edited externally to codesys, but it will be resolved when the files are imported. The way this works is the XML file is natively imported, then the structured text definition is copied over the top of the textual definition of the GVL.