### PR TITLE
8 make a precommit hook to remove the timestamp changes from the plc xml files

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,3 +133,7 @@ Once installed, proceed to [Adding the Script Toolbar to CODESYS](#adding-the-sc
 
 - https://help.codesys.com/webapp/idx-scriptingengine;product=ScriptEngine;version=3.5.10.0
 - `C:\<CODESYS INSTALL LOCATION>\CODESYS\Online Help\en\ScriptEngine.chm`
+
+## Similar Projects
+
+- https://github.com/18thCentury/CodeSys

--- a/src/communication_import_export.py
+++ b/src/communication_import_export.py
@@ -1,5 +1,6 @@
 import os
 
+from import_export import write_native
 from object_type import ObjectType
 from util import *
 
@@ -25,8 +26,8 @@ def export_communication(communication_obj, device_folder):
         top_level_device_folder = os.path.join(communication_folder, top_level_device.get_name())
         os.mkdir(top_level_device_folder)
         for child_device in top_level_device.get_children():
-            child_device.export_native(
-                os.path.join(top_level_device_folder, child_device.get_name() + ".xml"), recursive=True
+            write_native(
+                child_device, os.path.join(top_level_device_folder, child_device.get_name() + ".xml"), recursive=True
             )
 
 

--- a/src/import_export.py
+++ b/src/import_export.py
@@ -36,42 +36,29 @@ def import_st_decl_only(f, obj):
 
 
 def write_native(obj, path, recursive=False):
-    print(path)
-    # if get_object_type(obj) == ObjectType.CALL_TO_POU:
-    #     return
-
     obj.export_native(path, recursive=recursive)
 
     with open(path, "r+") as f:
         lines = f.read()
-        # uuid_replaced = re.sub(r'(^.+<Single Name="(?:EventPOUGuid|ParentSVNodeGuid|ParentGuid|LmGuid|LmStructTypeGuid|LmArrayTypeGuid|IoConfigGlobalsGuid|IoConfigGLobalsMappingGuid|IoConfigVarConfigGuid|IoConfigErrorPouGuid)".+?>).+(<\/Single>$)',r"\g<1>00000000-0000-0000-0000-000000000000\g<2>", lines, flags=re.MULTILINE)
+        # uuid_replaced = re.sub(
+        #     r'(^.+<Single Name="(?:EventPOUGuid|ParentSVNodeGuid|ParentGuid|LmGuid|LmStructTypeGuid|LmArrayTypeGuid|IoConfigGlobalsGuid|IoConfigGLobalsMappingGuid|IoConfigVarConfigGuid|IoConfigErrorPouGuid)".+?>).+(<\/Single>$)',
+        #     r"\g<1>00000000-0000-0000-0000-000000000000\g<2>",
+        #     lines,
+        #     flags=re.MULTILINE,
+        # )
         timestamp_replaced = re.sub(
-            r'(^.+<Single Name="(?:Timestamp)".+?>).+(<\/Single>$)', r"\g<1>0\g<2>", lines, flags=re.MULTILINE
+            r'(^.+<Single Name="(?:Timestamp|Id)" Type="long">).+(<\/Single>$)',
+            r"\g<1>0\g<2>",
+            lines,
+            flags=re.MULTILINE,
         )
         f.seek(0)
         f.write(timestamp_replaced)
         f.truncate()
 
-    # if recursive and len(obj.get_children()) > 0:
-    #     curr_folder = os.path.dirname(path)
-    #     child_obj_folder = os.path.join(curr_folder, obj.get_name() + NATIVE_EXPORT_POSTFIX)
-    #     os.mkdir(child_obj_folder)
-    #     for child_obj in obj.get_children():
-    #         write_native(child_obj, os.path.join(child_obj_folder, child_obj.get_name() + ".xml"), recursive=True)
-
 
 def read_native(f, obj):
-    print(f)
     obj.import_native(f)
-    # curr_folder, filename = os.path.split(f)
-    # name, _ = os.path.splitext(filename)
-    # imported_obj = first_or_error(obj.find(name), name + "should have been created, but cannot be found")
-    # native_export_folder_path = os.path.join(curr_folder, name + NATIVE_EXPORT_POSTFIX)
-    # if os.path.exists(native_export_folder_path) and os.path.isdir(native_export_folder_path):
-    #     for o in os.listdir(native_export_folder_path):
-    #         _, ext = os.path.splitext(o)
-    #         if ext == "xml":
-    #             read_native(os.path.join(native_export_folder_path, o), imported_obj)
 
 
 def export_folder(child_obj, parent_obj, parent_folder_path, export_child_fn):

--- a/src/import_export.py
+++ b/src/import_export.py
@@ -38,6 +38,7 @@ def import_st_decl_only(f, obj):
 def write_native(obj, path, recursive=False):
     obj.export_native(path, recursive=recursive)
 
+    # using regex instead of an xml parser because it is much quicker (sorry)
     with open(path, "r+") as f:
         lines = f.read()
         # uuid_replaced = re.sub(
@@ -46,6 +47,8 @@ def write_native(obj, path, recursive=False):
         #     lines,
         #     flags=re.MULTILINE,
         # )
+
+        # match any tags with Timestamp or Id and replace their contents with "0"
         timestamp_replaced = re.sub(
             r'(^.+<Single Name="(?:Timestamp|Id)" Type="long">).+(<\/Single>$)',
             r"\g<1>0\g<2>",

--- a/src/import_export.py
+++ b/src/import_export.py
@@ -8,8 +8,6 @@ from util import *
 IMPLEMENTATION_DELIMITER_SPLIT = "// --- BEGIN IMPLEMENTATION ---"
 IMPLEMENTATION_DELIMITER_INSERT = "\n" + IMPLEMENTATION_DELIMITER_SPLIT + "\n\n"
 
-NATIVE_EXPORT_POSTFIX = "_NATIVE_EXP"
-
 
 def write_st(obj, f):
     f.write(obj.textual_declaration.text)

--- a/src/import_export.py
+++ b/src/import_export.py
@@ -1,11 +1,14 @@
 # REMEMBER: this is python 2.7
 import os
+import re
 
 from object_type import ObjectType, get_object_type
 from util import *
 
 IMPLEMENTATION_DELIMITER_SPLIT = "// --- BEGIN IMPLEMENTATION ---"
 IMPLEMENTATION_DELIMITER_INSERT = "\n" + IMPLEMENTATION_DELIMITER_SPLIT + "\n\n"
+
+NATIVE_EXPORT_POSTFIX = "_NATIVE_EXP"
 
 
 def write_st(obj, f):
@@ -30,6 +33,45 @@ def import_st_decl_only(f, obj):
     f.seek(0)
     content = str(f.read())
     obj.textual_declaration.replace(content.strip() + "\n")
+
+
+def write_native(obj, path, recursive=False):
+    print(path)
+    # if get_object_type(obj) == ObjectType.CALL_TO_POU:
+    #     return
+
+    obj.export_native(path, recursive=recursive)
+
+    with open(path, "r+") as f:
+        lines = f.read()
+        # uuid_replaced = re.sub(r'(^.+<Single Name="(?:EventPOUGuid|ParentSVNodeGuid|ParentGuid|LmGuid|LmStructTypeGuid|LmArrayTypeGuid|IoConfigGlobalsGuid|IoConfigGLobalsMappingGuid|IoConfigVarConfigGuid|IoConfigErrorPouGuid)".+?>).+(<\/Single>$)',r"\g<1>00000000-0000-0000-0000-000000000000\g<2>", lines, flags=re.MULTILINE)
+        timestamp_replaced = re.sub(
+            r'(^.+<Single Name="(?:Timestamp)".+?>).+(<\/Single>$)', r"\g<1>0\g<2>", lines, flags=re.MULTILINE
+        )
+        f.seek(0)
+        f.write(timestamp_replaced)
+        f.truncate()
+
+    # if recursive and len(obj.get_children()) > 0:
+    #     curr_folder = os.path.dirname(path)
+    #     child_obj_folder = os.path.join(curr_folder, obj.get_name() + NATIVE_EXPORT_POSTFIX)
+    #     os.mkdir(child_obj_folder)
+    #     for child_obj in obj.get_children():
+    #         write_native(child_obj, os.path.join(child_obj_folder, child_obj.get_name() + ".xml"), recursive=True)
+
+
+def read_native(f, obj):
+    print(f)
+    obj.import_native(f)
+    # curr_folder, filename = os.path.split(f)
+    # name, _ = os.path.splitext(filename)
+    # imported_obj = first_or_error(obj.find(name), name + "should have been created, but cannot be found")
+    # native_export_folder_path = os.path.join(curr_folder, name + NATIVE_EXPORT_POSTFIX)
+    # if os.path.exists(native_export_folder_path) and os.path.isdir(native_export_folder_path):
+    #     for o in os.listdir(native_export_folder_path):
+    #         _, ext = os.path.splitext(o)
+    #         if ext == "xml":
+    #             read_native(os.path.join(native_export_folder_path, o), imported_obj)
 
 
 def export_folder(child_obj, parent_obj, parent_folder_path, export_child_fn):
@@ -72,7 +114,7 @@ def export_gvl(child_obj, parent_obj, parent_folder_path, export_child_fn):
     Exports native xml and structured text representation.
     This is because we need to support EVL and NVL as well, using this function.
     """
-    child_obj.export_native(os.path.join(parent_folder_path, child_obj.get_name() + ".gvl.xml"), recursive=False)
+    write_native(child_obj, os.path.join(parent_folder_path, child_obj.get_name() + ".gvl.xml"), recursive=False)
     with open(os.path.join(parent_folder_path, child_obj.get_name() + ".gvl.st"), "w") as f:
         write_st_decl_only(child_obj, f)
 
@@ -104,15 +146,15 @@ def import_gvl(child, dir_path, dir_parent_obj, import_dir_fn):
 
 
 def export_native(child_obj, parent_obj, parent_folder_path, export_child_fn):
-    child_obj.export_native(os.path.join(parent_folder_path, child_obj.get_name() + ".xml"), recursive=False)
+    write_native(child_obj, os.path.join(parent_folder_path, child_obj.get_name() + ".xml"), recursive=False)
 
 
 def export_native_recursive(child_obj, parent_obj, parent_folder_path, export_child_fn):
-    child_obj.export_native(os.path.join(parent_folder_path, child_obj.get_name() + ".xml"), recursive=True)
+    write_native(child_obj, os.path.join(parent_folder_path, child_obj.get_name() + ".xml"), recursive=True)
 
 
 def import_native(child, dir_path, dir_parent_obj, import_dir_fn):
-    dir_parent_obj.import_native(os.path.join(dir_path, child))
+    read_native(os.path.join(dir_path, child), dir_parent_obj)
 
 
 def export_dut(child_obj, parent_obj, parent_folder_path, export_child_fn):
@@ -135,7 +177,8 @@ def export_method(child_obj, parent_obj, parent_folder_path, export_child_fn):
         ) as f:
             write_st(child_obj, f)
     else:
-        child_obj.export_native(
+        write_native(
+            child_obj,
             os.path.join(parent_folder_path, parent_obj.get_name() + "." + child_obj.get_name() + ".xml"),
             recursive=False,
         )
@@ -157,8 +200,10 @@ def import_method_st(child, dir_path, dir_parent_obj, import_dir_fn):
 
 
 def export_sub_pou(child_obj, parent_obj, parent_folder_path, export_child_fn):
-    child_obj.export_native(
-        os.path.join(parent_folder_path, parent_obj.get_name() + "." + child_obj.get_name() + ".xml"), recursive=True
+    write_native(
+        child_obj,
+        os.path.join(parent_folder_path, parent_obj.get_name() + "." + child_obj.get_name() + ".xml"),
+        recursive=True,
     )
 
 

--- a/src/import_from_files.py
+++ b/src/import_from_files.py
@@ -24,7 +24,7 @@ def import_directory_child(child, dir_path, dir_parent_obj):
     full_path = os.path.join(dir_path, child)
     filename, ext = os.path.splitext(child)
 
-    if os.path.isdir(full_path) and not filename.endswith(NATIVE_EXPORT_POSTFIX):
+    if os.path.isdir(full_path):
         import_folder(child, dir_path, dir_parent_obj, import_directory)
 
     if filename.endswith(".gvl"):

--- a/src/import_from_files.py
+++ b/src/import_from_files.py
@@ -24,7 +24,7 @@ def import_directory_child(child, dir_path, dir_parent_obj):
     full_path = os.path.join(dir_path, child)
     filename, ext = os.path.splitext(child)
 
-    if os.path.isdir(full_path):
+    if os.path.isdir(full_path) and not filename.endswith(NATIVE_EXPORT_POSTFIX):
         import_folder(child, dir_path, dir_parent_obj, import_directory)
 
     if filename.endswith(".gvl"):

--- a/src/object_type.py
+++ b/src/object_type.py
@@ -29,6 +29,10 @@ class ObjectType:
         return elements
 
 
+# Other mapping lists:
+# https://github.com/tkucic/codesys_workflow_automation/blob/main/src/codesysBulker.py#L9
+# https://github.com/18thCentury/CodeSys/blob/master/export.py#L10
+
 GUID_TYPE_MAPPING = {
     "6f9dac99-8de1-4efc-8465-68ac443b7d08": ObjectType.POU,
     "2db5746d-d284-4425-9f7f-2663a34b0ebc": ObjectType.DUT,

--- a/src/object_type.py
+++ b/src/object_type.py
@@ -17,6 +17,7 @@ class ObjectType:
     PROJECT_SETTINGS = "PROJECT_SETTINGS"
     DEVICE = "DEVICE"
     FOLDER = "FOLDER"
+    CALL_TO_POU = "CALL_TO_POU"
     UNKNOWN = "UNKNOWN"
 
     @classmethod
@@ -43,6 +44,7 @@ GUID_TYPE_MAPPING = {
     "8753fe6f-4a22-4320-8103-e553c4fc8e04": ObjectType.PROJECT_SETTINGS,
     "225bfe47-7336-4dbc-9419-4105a7c831fa": ObjectType.DEVICE,
     "738bea1e-99bb-4f04-90bb-a7a567e74e3a": ObjectType.FOLDER,
+    "413e2a7d-adb1-4d2c-be29-6ae6e4fab820": ObjectType.CALL_TO_POU,
 }
 
 


### PR DESCRIPTION
Remove changes like this in the git diff:
![image](https://github.com/user-attachments/assets/9b6c262e-3264-4661-a7a1-57e434482f2b)

I decided this was better done by setting the timestamps to zero in the export, rather than trying to "patch" it in a precommit hook.

This change uses a regular expression to find any tags matching `<Single Name="Timestamp" Type="long">` and  `<Single Name="Id" Type="long">` and sets their contents to `"0"`, when we do a "native" XML export.

Note there are still UUIDS in the XML export that change unnecessarily, but during my testing I found that there wasn't any consistent value we could set them to that would import correctly. So for the moment, we have to just accept uuid changes in the git diff:
![image](https://github.com/user-attachments/assets/ca1c3c6e-5236-4ca2-8a9e-3dc3c36e45fb)

I left a commented out regular expression in the `write_native` function to match and replace UUIDs, if we ever want to revisit this.