### PR TITLE
Improve UTF-8 exports and configurable script paths

### DIFF
--- a/Plan.md
+++ b/Plan.md
@@ -1,0 +1,320 @@
+CODESCRIBE – implementation brief for Codex
+Goals
+
+UTF-8 safe exports/imports under Python 2.7 (CODESYS ScriptEngine) — no more 'ascii' codec errors on smart punctuation.
+
+Stable filenames derived from object names (no illegal chars, no Unicode surprises).
+
+Configurable export target (CLI arg + safe default) to avoid file locks when the project is open.
+
+Actionable errors & logs for typical failures (locked files, path issues).
+
+Zero regressions on existing behavior for users who don’t pass args.
+
+Constraints
+
+Runtime is Python 2.7.7 (CODESYS ScriptEngine 3.5.10.30).
+
+Do not require external packages.
+
+Maintain compatibility with existing project structure and scripts.
+
+Acceptance criteria
+
+A project containing Unicode (en/em dashes, smart quotes, NBSP) exports without error.
+
+Resulting files are UTF-8 encoded.
+
+Object names with odd chars produce safe filenames (ASCII-only, filesystem-safe).
+
+Export To Files works while the .project is open by exporting to a separate path (when provided).
+
+Import path can be overridden similarly.
+
+Clear console messages when:
+
+destination exists and can’t be removed,
+
+path isn’t writable,
+
+a file is locked,
+
+config/args are invalid.
+
+File-by-file work
+1) src/util.py (ADD Unicode + file helpers)
+
+Replace with / extend to include:
+
+# -*- coding: utf-8 -*-
+# Python 2.7 compatible
+
+import os, io, re, sys
+try:
+    import unicodedata
+except Exception:
+    unicodedata = None
+
+import scriptengine  # type: ignore
+from object_type import get_object_type
+
+# ---- existing helpers kept (print_python_version, assert_*, first_* ) ----
+# keep your current functions here; append the following:
+
+SMART_MAP = {
+    u'\u2013': u'-',  # en dash
+    u'\u2014': u'-',  # em dash
+    u'\u2018': u"'",  # left single quote
+    u'\u2019': u"'",  # right single quote
+    u'\u201c': u'"',  # left double quote
+    u'\u201d': u'"',  # right double quote
+    u'\xa0' : u' ',   # non-breaking space
+}
+
+def _to_u(s):
+    try:
+        return s if isinstance(s, unicode) else unicode(s, 'utf-8', 'ignore')
+    except NameError:
+        return s
+
+def sanitize_text(s):
+    u = _to_u(s)
+    for k, v in SMART_MAP.items():
+        u = u.replace(k, v)
+    return u
+
+def safe_filename(name):
+    u = sanitize_text(name)
+    if unicodedata:
+        u = unicodedata.normalize('NFKD', u)
+    try:
+        u = u.encode('ascii', 'ignore').decode('ascii')
+    except Exception:
+        pass
+    u = re.sub(r'[^\w\-. ]+', '_', u)
+    u = u.strip().rstrip('.')
+    return u or 'unnamed'
+
+def ensure_dir(d):
+    if d and not os.path.isdir(d):
+        os.makedirs(d)
+
+def write_file(path, text):
+    """UTF-8 writer with newline normalization + sanitization."""
+    ensure_dir(os.path.dirname(path))
+    with io.open(path, 'w', encoding='utf-8', newline=u'\n') as f:
+        f.write(sanitize_text(_to_u(text)))
+
+2) src/import_export.py (USE write_file + safe_filename)
+
+At top: from util import write_file, safe_filename
+
+Wherever you build output paths from object names, wrap with safe_filename(name).
+
+Replace any open(out_path, 'w') blocks with write_file(out_path, text).
+
+Example change:
+
+# BEFORE
+out_path = os.path.join(parent_dir, child.get_name() + '.st')
+with open(out_path, 'w') as f:
+    f.write(text)
+
+# AFTER
+out_path = os.path.join(parent_dir, safe_filename(child.get_name()) + '.st')
+write_file(out_path, text)
+
+3) src/communication_import_export.py (same treatment)
+
+from util import write_file, safe_filename
+
+Wrap names with safe_filename(...)
+
+Replace file writes with write_file(...).
+
+4) src/entrypoint.py (ADD helpers for destination override)
+
+Add two helpers (non-breaking for existing callers):
+
+import os, sys
+
+def get_export_target(project_path, project_name, argv=None):
+    """
+    If argv[1] provided, use it as the export root (absolute or relative).
+    Else, default to sibling '<ProjectName>ST' beside project.
+    """
+    argv = argv or sys.argv
+    if len(argv) > 1 and argv[1]:
+        return os.path.abspath(argv[1])
+    parent = os.path.dirname(project_path)
+    return os.path.join(parent, project_name + "ST")
+
+def get_import_source(project_path, project_name, argv=None):
+    """
+    If argv[1] provided, use it as the import source folder.
+    Else, default to sibling '<ProjectName>ST'.
+    """
+    argv = argv or sys.argv
+    if len(argv) > 1 and argv[1]:
+        return os.path.abspath(argv[1])
+    parent = os.path.dirname(project_path)
+    return os.path.join(parent, project_name + "ST")
+
+
+(Keep existing find_application, find_communication, get_device_entrypoints, get_src_folder (if used elsewhere), but migrate scripts to new helpers.)
+
+5) src/script_export_to_files.py (SUPPORT dest arg + robust errors)
+
+At top: import io, sys, shutil, os
+
+Import new helpers: from entrypoint import find_application, find_communication, get_device_entrypoints, get_export_target
+
+Replace get_src_folder(...) usage with get_export_target(project_path, project_name, sys.argv)
+
+Before deleting an existing folder, print a clear message; add --force behavior if desired.
+
+Proposed body:
+
+# REMEMBER: python 2.7
+from __future__ import print_function
+import os, sys, shutil
+import scriptengine  # type: ignore
+
+from communication_import_export import export_communication
+from entrypoint import find_application, find_communication, get_device_entrypoints, get_export_target
+from util import print_python_version, assert_project_open
+
+def _project_info():
+    p = scriptengine.projects.primary
+    project_path = p.get_path()
+    project_name = os.path.splitext(os.path.basename(project_path))[0]
+    return project_path, project_name
+
+try:
+    print_python_version()
+    assert_project_open()
+
+    project_path, project_name = _project_info()
+    out_dir = get_export_target(project_path, project_name, sys.argv)
+    print("Writing to: " + out_dir)
+
+    if os.path.exists(out_dir):
+        try:
+            shutil.rmtree(out_dir)
+        except Exception as ex:
+            print("WARN: could not remove existing dir '{}': {}".format(out_dir, ex))
+            raise
+    os.makedirs(out_dir)
+
+    for device_obj in get_device_entrypoints(scriptengine.projects.primary):
+        device_folder = os.path.join(out_dir, device_obj.get_name())
+        os.mkdir(device_folder)
+
+        application = find_application(device_obj)
+        application_folder = os.path.join(device_folder, "application")
+        os.mkdir(application_folder)
+
+        for child_obj in application.get_children():
+            # export_child comes from import_export module (kept as-is),
+            # ensure it relies on util.write_file + util.safe_filename internally.
+            from import_export import export_child
+            export_child(child_obj, application, application_folder)
+
+        communication = find_communication(device_obj)
+        export_communication(communication, device_folder)
+
+except Exception as e:
+    # Show actionable hint for common Windows lock
+    print(e)
+    print("HINT: If you see [Errno 13] access denied, close editors/Explorer/OneDrive locking the export folder or export to a different path via argv.")
+    raise
+
+print("Done!")
+
+
+Note: move export_child definition to import_export.py (it already conceptually belongs there), or import it where it currently lives.
+
+6) src/script_import_from_files.py (SUPPORT source arg)
+
+Import get_import_source, accept sys.argv[1] as import root; otherwise default to sibling <ProjectName>ST.
+
+Print source path; errors should mention how to pass a different folder.
+
+Sketch:
+
+from __future__ import print_function
+import os, sys
+import scriptengine  # type: ignore
+from entrypoint import get_import_source
+from util import print_python_version, assert_project_open
+
+try:
+    print_python_version()
+    assert_project_open()
+
+    p = scriptengine.projects.primary
+    project_path = p.get_path()
+    project_name = os.path.splitext(os.path.basename(project_path))[0]
+    src_dir = get_import_source(project_path, project_name, sys.argv)
+    print("Importing from: " + src_dir)
+
+    # existing import logic continues, reading files from src_dir
+except Exception as e:
+    print(e)
+    raise
+
+7) (Optional) README.md updates
+
+Add usage examples for ScriptEngine console:
+
+# Export to a custom folder (avoid file locks)
+Tools → Scripting → Scripting Console:
+
+import sys
+sys.argv = [r"C:\codescribe\src\script_export_to_files.py",
+            r"C:\_exports\IceMachine_Run1"]
+execfile(r"C:\codescribe\src\script_export_to_files.py")
+
+# Import from a custom folder
+sys.argv = [r"C:\codescribe\src\script_import_from_files.py",
+            r"C:\_exports\IceMachine_Run1"]
+execfile(r"C:\codescribe\src\script_import_from_files.py")
+
+
+Mention UTF-8 and filename sanitation.
+
+Manual test plan
+
+Unicode project content
+
+Insert comments/names containing: – — “ ” ‘ ’ (NBSP) in POUs/Methods/Devices.
+
+Run Export To Files (toolbar or console with custom path) → ✅ no ASCII errors; files appear.
+
+Filename safety
+
+Create POUs with names like Seal—Bar / Closed? → output filenames should be sane, e.g., Seal-Bar _ Closed_.st.
+
+Custom export path
+
+With the project open on Desktop, export to C:\_exports\Run_1 via console arg → ✅ succeeds, no [Errno 13].
+
+Import round-trip
+
+Edit an exported .st, run Import From Files with the same custom path → changes appear in CODESYS.
+
+Lock handling
+
+Open the export folder in Explorer with Preview Pane on; attempt export to the same folder → should either succeed (clean rmtree) or emit a clear warning and stop; then succeed to a new path.
+
+Notes to Codex
+
+Keep changes Python 2.7 compatible (no f-strings, no pathlib).
+
+Don’t add third-party deps.
+
+Minimize surface area: centralize writing/filenaming in util.py and ensure all export code paths call those helpers.
+
+If any module performs its own open(..., 'w'), convert to write_file(...).
+
+That’s everything needed.

--- a/README.md
+++ b/README.md
@@ -39,6 +39,27 @@ The following items are exported:
 
 Items are exported in formatted structured text (`.st`) where possible, and in native CODESYS xml everywhere else.
 
+## Unicode & Safe Filenames
+
+CODESCRIBE normalises smart punctuation (e.g. smart quotes, en/em dashes, non-breaking spaces) to plain ASCII during export so that files always save as UTF-8 without raising `ascii` codec errors. Object names are converted to filesystem-safe ASCII, replacing unsupported characters with underscores while preserving readability.
+
+## Custom Export and Import Paths
+
+You can direct the export and import scripts to a specific folder by setting `sys.argv[1]` before executing them in the ScriptEngine console. This avoids file-lock issues when the project is open and lets you work from dedicated folders.
+
+```python
+# Export to a custom folder
+import sys
+sys.argv = [r"C:\codescribe\src\script_export_to_files.py",
+            r"C:\_exports\IceMachine_Run1"]
+execfile(r"C:\codescribe\src\script_export_to_files.py")
+
+# Import from a custom folder
+sys.argv = [r"C:\codescribe\src\script_import_from_files.py",
+            r"C:\_exports\IceMachine_Run1"]
+execfile(r"C:\codescribe\src\script_import_from_files.py")
+```
+
 ## Project Templates
 
 The intention of CODESCRIBE is not to export a complete copy of the project, but to only export the implementation logic of the project, enabling collaboration via git and other source control methods. An empty, but configured, underlying project file should also be committed to the repo to manage any other configuration that CODESYS provides (e.g. project level configuration, device configuration). For example, `Example Project_template_v1.project`:

--- a/src/communication_import_export.py
+++ b/src/communication_import_export.py
@@ -1,8 +1,8 @@
 import os
 
 from import_export import write_native
-from object_type import ObjectType
-from util import *
+from object_type import ObjectType, get_object_type
+from util import first_of_type_or_error, first_of_type_or_none, register_directory, resolve_original_name, safe_filename
 
 NO_EXPORT_FOLDER_NAME = "_NO_EXPORT"
 
@@ -19,15 +19,24 @@ def export_communication(communication_obj, device_folder):
     if no_export_folder_exists(communication_obj):
         return
 
-    communication_folder = os.path.join(device_folder, "communication")
+    communication_folder_name = "communication"
+    communication_folder = os.path.join(device_folder, communication_folder_name)
     os.mkdir(communication_folder)
+    register_directory(device_folder, communication_folder_name, communication_obj.get_name())
 
     for top_level_device in communication_obj.get_children():
-        top_level_device_folder = os.path.join(communication_folder, top_level_device.get_name())
+        safe_device_name = safe_filename(top_level_device.get_name())
+        top_level_device_folder = os.path.join(communication_folder, safe_device_name)
         os.mkdir(top_level_device_folder)
+        register_directory(communication_folder, safe_device_name, top_level_device.get_name())
         for child_device in top_level_device.get_children():
+            child_safe_name = safe_filename(child_device.get_name())
             write_native(
-                child_device, os.path.join(top_level_device_folder, child_device.get_name() + ".xml"), recursive=True
+                child_device,
+                os.path.join(top_level_device_folder, child_safe_name + ".xml"),
+                recursive=True,
+                original_name=child_device.get_name(),
+                parent_name=top_level_device.get_name(),
             )
 
 
@@ -38,15 +47,14 @@ def import_communication(communication_obj, device_folder):
 
     remove_tracked_communication_devices(communication_obj)
 
-    # for top level folders inside the communcation folder, do a native import on the corresponding communication device
+    # for top level folders inside the communication folder, do a native import on the corresponding communication device
     for name in os.listdir(communication_folder):
         full_path = os.path.join(communication_folder, name)
         if not os.path.isdir(full_path):
             continue
 
-        top_level_device = first_of_type_or_error(
-            communication_obj.find(name), ObjectType.DEVICE, "Cannot find communication device with name " + name
-        )
+        original_name = resolve_original_name(communication_folder, name, default=name)
+        top_level_device = _find_top_level_device(communication_obj, original_name, safe_name=name)
         for child_name in os.listdir(full_path):
             _, ext = os.path.splitext(child_name)
             if ext == ".xml":
@@ -61,3 +69,17 @@ def remove_tracked_communication_devices(communication_obj):
     for top_level_device in communication_obj.get_children():
         for child in top_level_device.get_children():
             child.remove()
+
+
+def _find_top_level_device(communication_obj, export_name, safe_name=None):
+    err = "Cannot find communication device with name " + export_name
+    try:
+        return first_of_type_or_error(communication_obj.find(export_name), ObjectType.DEVICE, err)
+    except ValueError:
+        target_safe = safe_name or safe_filename(export_name)
+        for candidate in communication_obj.get_children():
+            if get_object_type(candidate) != ObjectType.DEVICE:
+                continue
+            if safe_filename(candidate.get_name()) == target_safe:
+                return candidate
+        raise ValueError(err)

--- a/src/entrypoint.py
+++ b/src/entrypoint.py
@@ -1,6 +1,46 @@
 # REMEMBER: this is python 2.7
+import os
+import sys
+
 from object_type import ObjectType, get_object_type
-from util import *
+from util import first_or_error
+
+
+def get_project_path(project):
+    """
+    Return the on-disk path to the current project.
+
+    Older ScriptProject objects expose `.path` instead of `.get_path()`, so we
+    try the method first and fall back to the attribute for compatibility.
+    """
+    path_getter = getattr(project, "get_path", None)
+    if callable(path_getter):
+        return path_getter()
+    if hasattr(project, "path"):
+        return project.path
+    raise AttributeError("ScriptProject does not expose get_path() or path.")
+
+
+def get_export_target(project_path, project_name, argv=None):
+    """
+    Determine export destination.
+    """
+    argv = argv or sys.argv
+    if len(argv) > 1 and argv[1]:
+        return os.path.abspath(argv[1])
+    parent = os.path.dirname(project_path)
+    return os.path.join(parent, project_name + "ST")
+
+
+def get_import_source(project_path, project_name, argv=None):
+    """
+    Determine import source directory.
+    """
+    argv = argv or sys.argv
+    if len(argv) > 1 and argv[1]:
+        return os.path.abspath(argv[1])
+    parent = os.path.dirname(project_path)
+    return os.path.join(parent, project_name + "ST")
 
 
 def get_src_folder(project):

--- a/src/import_export.py
+++ b/src/import_export.py
@@ -3,20 +3,34 @@ import os
 import re
 
 from object_type import ObjectType, get_object_type
-from util import *
+from util import (
+    first_of_type_or_error,
+    get_original_entry,
+    register_directory,
+    register_original_name,
+    resolve_original_name,
+    safe_filename,
+    write_file,
+)
 
 IMPLEMENTATION_DELIMITER_SPLIT = "// --- BEGIN IMPLEMENTATION ---"
 IMPLEMENTATION_DELIMITER_INSERT = "\n" + IMPLEMENTATION_DELIMITER_SPLIT + "\n\n"
 
 
+def _render_st(obj):
+    return obj.textual_declaration.text + IMPLEMENTATION_DELIMITER_INSERT + obj.textual_implementation.text
+
+
+def _render_st_decl_only(obj):
+    return obj.textual_declaration.text
+
+
 def write_st(obj, f):
-    f.write(obj.textual_declaration.text)
-    f.write(IMPLEMENTATION_DELIMITER_INSERT)
-    f.write(obj.textual_implementation.text)
+    f.write(_render_st(obj))
 
 
 def write_st_decl_only(obj, f):
-    f.write(obj.textual_declaration.text)
+    f.write(_render_st_decl_only(obj))
 
 
 def import_st(f, obj):
@@ -33,7 +47,7 @@ def import_st_decl_only(f, obj):
     obj.textual_declaration.replace(content.strip() + "\n")
 
 
-def write_native(obj, path, recursive=False):
+def write_native(obj, path, recursive=False, original_name=None, parent_name=None):
     obj.export_native(path, recursive=recursive)
 
     # using regex instead of an xml parser because it is much quicker (sorry)
@@ -70,32 +84,49 @@ def write_native(obj, path, recursive=False):
         f.write(timestamp_replaced)
         f.truncate()
 
+    register_original_name(
+        os.path.dirname(path),
+        os.path.basename(path),
+        original_name or obj.get_name(),
+        parent_name=parent_name,
+        kind="file",
+    )
+
 
 def read_native(f, obj):
     obj.import_native(f)
 
 
 def export_folder(child_obj, parent_obj, parent_folder_path, export_child_fn):
-    child_obj_folder = os.path.join(parent_folder_path, child_obj.get_name())
+    safe_child_name = safe_filename(child_obj.get_name())
+    child_obj_folder = os.path.join(parent_folder_path, safe_child_name)
     os.mkdir(child_obj_folder)
+    register_directory(parent_folder_path, safe_child_name, child_obj.get_name())
     for c in child_obj.get_children():
         export_child_fn(c, child_obj, child_obj_folder)
 
 
 def import_folder(child, dir_path, dir_parent_obj, import_dir_fn):
-    dir_parent_obj.create_folder(child)
+    folder_name = resolve_original_name(dir_path, child, default=child)
+    dir_parent_obj.create_folder(folder_name)
     folder_obj = first_of_type_or_error(
-        dir_parent_obj.find(child),
+        dir_parent_obj.find(folder_name),
         ObjectType.FOLDER,
-        "Folder of name " + child + " should have been created, but cannot be found",
+        "Folder of name " + folder_name + " should have been created, but cannot be found",
     )
     import_dir_fn(os.path.join(dir_path, child), folder_obj)
 
 
 def export_pou(child_obj, parent_obj, parent_folder_path, export_child_fn):
     if child_obj.has_textual_implementation:
-        with open(os.path.join(parent_folder_path, child_obj.get_name() + ".st"), "w") as f:
-            write_st(child_obj, f)
+        safe_child_name = safe_filename(child_obj.get_name())
+        out_path = os.path.join(parent_folder_path, safe_child_name + ".st")
+        write_file(
+            out_path,
+            _render_st(child_obj),
+            original_name=child_obj.get_name(),
+            parent_name=parent_obj.get_name(),
+        )
     else:
         export_native(child_obj, parent_obj, parent_folder_path, export_child_fn)
 
@@ -105,7 +136,9 @@ def export_pou(child_obj, parent_obj, parent_folder_path, export_child_fn):
 
 def import_pou_st(child, dir_path, dir_parent_obj, import_dir_fn):
     filename, _ = os.path.splitext(child)
-    pou_obj = dir_parent_obj.create_pou(filename)
+    entry = get_original_entry(dir_path, child)
+    pou_name = entry.get("name") if entry and entry.get("name") else filename
+    pou_obj = dir_parent_obj.create_pou(pou_name)
     with open(os.path.join(dir_path, child), "r") as f:
         import_st(f, pou_obj)
 
@@ -115,43 +148,72 @@ def export_gvl(child_obj, parent_obj, parent_folder_path, export_child_fn):
     Exports native xml and structured text representation.
     This is because we need to support EVL and NVL as well, using this function.
     """
-    write_native(child_obj, os.path.join(parent_folder_path, child_obj.get_name() + ".gvl.xml"), recursive=False)
-    with open(os.path.join(parent_folder_path, child_obj.get_name() + ".gvl.st"), "w") as f:
-        write_st_decl_only(child_obj, f)
+    base_name = safe_filename(child_obj.get_name())
+    write_native(
+        child_obj,
+        os.path.join(parent_folder_path, base_name + ".gvl.xml"),
+        recursive=False,
+        original_name=child_obj.get_name(),
+        parent_name=parent_obj.get_name(),
+    )
+    write_file(
+        os.path.join(parent_folder_path, base_name + ".gvl.st"),
+        _render_st_decl_only(child_obj),
+        original_name=child_obj.get_name(),
+        parent_name=parent_obj.get_name(),
+    )
 
 
 def import_gvl(child, dir_path, dir_parent_obj, import_dir_fn):
     """
     Import the native xml and then overwrite the textual definition with the structured text.
     """
-    name, ext = os.path.splitext(child)
+    name_safe, ext = os.path.splitext(child)
 
-    if ".gvl" not in name:
+    if ".gvl" not in name_safe:
         raise ValueError(".gvl not in file name!")
 
-    name = name.replace(".gvl", "")
+    base_safe = name_safe.replace(".gvl", "")
+    entry = get_original_entry(dir_path, child)
+    object_name = entry.get("name") if entry and entry.get("name") else base_safe
 
     if ext != ".st":
         raise ValueError("Expected GVL st file!")
 
-    gvl_xml_path = os.path.join(dir_path, name + ".gvl.xml")
+    gvl_xml_path = os.path.join(dir_path, base_safe + ".gvl.xml")
     if not os.path.exists(gvl_xml_path):
         raise ValueError("Expected GVL xml file at " + gvl_xml_path)
 
     import_native(gvl_xml_path, dir_path, dir_parent_obj, import_dir_fn)
     with open(os.path.join(dir_path, child), "r") as f:
         imported_obj = first_of_type_or_error(
-            dir_parent_obj.find(name), ObjectType.GVL, name + " GVL should have been created, but cannot be found"
+            dir_parent_obj.find(object_name),
+            ObjectType.GVL,
+            object_name + " GVL should have been created, but cannot be found",
         )
         import_st_decl_only(f, imported_obj)
 
 
 def export_native(child_obj, parent_obj, parent_folder_path, export_child_fn):
-    write_native(child_obj, os.path.join(parent_folder_path, child_obj.get_name() + ".xml"), recursive=False)
+    safe_child_name = safe_filename(child_obj.get_name())
+    write_native(
+        child_obj,
+        os.path.join(parent_folder_path, safe_child_name + ".xml"),
+        recursive=False,
+        original_name=child_obj.get_name(),
+        parent_name=parent_obj.get_name(),
+    )
 
 
 def export_native_recursive(child_obj, parent_obj, parent_folder_path, export_child_fn):
-    write_native(child_obj, os.path.join(parent_folder_path, child_obj.get_name() + ".xml"), recursive=True)
+    safe_child_name = safe_filename(child_obj.get_name())
+    write_native(
+        child_obj,
+        os.path.join(parent_folder_path, safe_child_name + ".xml"),
+        recursive=True,
+        original_name=child_obj.get_name(),
+        parent_name=parent_obj.get_name(),
+    )
 
 
 def import_native(child, dir_path, dir_parent_obj, import_dir_fn):
@@ -159,13 +221,19 @@ def import_native(child, dir_path, dir_parent_obj, import_dir_fn):
 
 
 def export_dut(child_obj, parent_obj, parent_folder_path, export_child_fn):
-    with open(os.path.join(parent_folder_path, child_obj.get_name() + ".st"), "w") as f:
-        f.write(child_obj.textual_declaration.text)
+    write_file(
+        os.path.join(parent_folder_path, safe_filename(child_obj.get_name()) + ".st"),
+        child_obj.textual_declaration.text,
+        original_name=child_obj.get_name(),
+        parent_name=parent_obj.get_name(),
+    )
 
 
 def import_dut(child, dir_path, dir_parent_obj, import_dir_fn):
     filename, _ = os.path.splitext(child)
-    dut_obj = dir_parent_obj.create_dut(filename)
+    entry = get_original_entry(dir_path, child)
+    dut_name = entry.get("name") if entry and entry.get("name") else filename
+    dut_obj = dir_parent_obj.create_dut(dut_name)
     with open(os.path.join(dir_path, child), "r") as f:
         f.seek(0)
         dut_obj.textual_declaration.replace(str(f.read()))
@@ -173,22 +241,36 @@ def import_dut(child, dir_path, dir_parent_obj, import_dir_fn):
 
 def export_method(child_obj, parent_obj, parent_folder_path, export_child_fn):
     if child_obj.has_textual_implementation:
-        with open(
-            os.path.join(parent_folder_path, parent_obj.get_name() + "." + child_obj.get_name() + ".st"), "w"
-        ) as f:
-            write_st(child_obj, f)
+        parent_name = safe_filename(parent_obj.get_name())
+        method_name = safe_filename(child_obj.get_name())
+        out_path = os.path.join(parent_folder_path, parent_name + "." + method_name + ".st")
+        write_file(
+            out_path,
+            _render_st(child_obj),
+            original_name=child_obj.get_name(),
+            parent_name=parent_obj.get_name(),
+        )
     else:
+        parent_name = safe_filename(parent_obj.get_name())
+        method_name = safe_filename(child_obj.get_name())
         write_native(
             child_obj,
-            os.path.join(parent_folder_path, parent_obj.get_name() + "." + child_obj.get_name() + ".xml"),
+            os.path.join(parent_folder_path, parent_name + "." + method_name + ".xml"),
             recursive=False,
+            original_name=child_obj.get_name(),
+            parent_name=parent_obj.get_name(),
         )
 
 
 def import_method_st(child, dir_path, dir_parent_obj, import_dir_fn):
     full_path = os.path.join(dir_path, child)
     filename, _ = os.path.splitext(child)
-    parent_name, method_name = filename.split(".")
+    parts = filename.split(".")
+    parent_safe = parts[0]
+    method_safe = parts[1] if len(parts) > 1 else parts[0]
+    entry = get_original_entry(dir_path, child)
+    parent_name = entry.get("parent") if entry and entry.get("parent") else parent_safe
+    method_name = entry.get("name") if entry and entry.get("name") else method_safe
     parent_obj = first_of_type_or_error(
         dir_parent_obj.find(parent_name),
         ObjectType.POU,
@@ -201,9 +283,11 @@ def import_method_st(child, dir_path, dir_parent_obj, import_dir_fn):
 
 
 def export_sub_pou(child_obj, parent_obj, parent_folder_path, export_child_fn):
+    parent_name = safe_filename(parent_obj.get_name())
+    child_name = safe_filename(child_obj.get_name())
     write_native(
         child_obj,
-        os.path.join(parent_folder_path, parent_obj.get_name() + "." + child_obj.get_name() + ".xml"),
+        os.path.join(parent_folder_path, parent_name + "." + child_name + ".xml"),
         recursive=True,
     )
 
@@ -211,7 +295,10 @@ def export_sub_pou(child_obj, parent_obj, parent_folder_path, export_child_fn):
 def import_sub_pou(child, dir_path, dir_parent_obj, import_dir_fn):
     full_path = os.path.join(dir_path, child)
     filename, _ = os.path.splitext(child)
-    parent_name = filename.split(".")[0]
+    parts = filename.split(".")
+    parent_safe = parts[0]
+    entry = get_original_entry(dir_path, child)
+    parent_name = entry.get("parent") if entry and entry.get("parent") else parent_safe
     parent_obj = first_of_type_or_error(
         dir_parent_obj.find(parent_name),
         ObjectType.POU,
@@ -234,6 +321,13 @@ OBJECT_TYPE_TO_EXPORT_FUNCTION = {
     ObjectType.ACTION: export_sub_pou,
     ObjectType.TRANSITION: export_sub_pou,
 }
+
+
+def export_child(child_obj, parent_obj, parent_folder_path):
+    child_obj_type = get_object_type(child_obj)
+    export_fn = OBJECT_TYPE_TO_EXPORT_FUNCTION.get(child_obj_type)
+    if export_fn is not None:
+        export_fn(child_obj, parent_obj, parent_folder_path, export_child)
 
 
 def remove_tracked_objects(obj_list):

--- a/src/import_from_files.py
+++ b/src/import_from_files.py
@@ -3,7 +3,7 @@ import os
 from communication_import_export import import_communication
 from entrypoint import find_application, find_communication, get_device_entrypoints, get_src_folder
 from import_export import *
-from util import *
+from util import assert_path_exists, find_safe_name, safe_filename
 
 
 def first_word_of_line_iter(f):
@@ -54,17 +54,23 @@ def import_directory_child(child, dir_path, dir_parent_obj):
                         import_pou_st(child, dir_path, dir_parent_obj, import_directory)
 
 
-def import_from_files(project):
-    src_folder = get_src_folder(project)
+def import_from_files(project, src_folder=None):
+    if src_folder is None:
+        src_folder = get_src_folder(project)
     print("Reading from: " + src_folder)
     assert_path_exists(src_folder)
 
     for device_obj in get_device_entrypoints(project):
-        device_folder = os.path.join(src_folder, device_obj.get_name())
+        safe_device_name = find_safe_name(src_folder, device_obj.get_name(), kind="dir") or safe_filename(
+            device_obj.get_name()
+        )
+        device_folder = os.path.join(src_folder, safe_device_name)
         assert_path_exists(device_folder)
 
         application = find_application(device_obj)
-        application_folder = os.path.join(device_folder, "application")
+        application_safe = find_safe_name(device_folder, application.get_name(), kind="dir") or "application"
+        application_folder = os.path.join(device_folder, application_safe)
+        assert_path_exists(application_folder)
         remove_tracked_objects(application.get_children())
         import_directory(application_folder, application)
 

--- a/src/script_export_to_files.py
+++ b/src/script_export_to_files.py
@@ -3,49 +3,67 @@ from __future__ import print_function
 
 import os
 import shutil
+import sys
 
 import scriptengine  # type: ignore
 
 from communication_import_export import export_communication
-from entrypoint import find_application, find_communication, get_device_entrypoints, get_src_folder
-from import_export import OBJECT_TYPE_TO_EXPORT_FUNCTION
-from object_type import get_object_type
-from util import *
+from entrypoint import (
+    find_application,
+    find_communication,
+    get_device_entrypoints,
+    get_export_target,
+    get_project_path,
+)
+from import_export import export_child
+from util import assert_project_open, print_python_version, register_directory, safe_filename
 
 
-def export_child(child_obj, parent_obj, parent_folder_path):
-    child_obj_type = get_object_type(child_obj)
-    export_fn = OBJECT_TYPE_TO_EXPORT_FUNCTION.get(child_obj_type)
-    if export_fn is not None:
-        export_fn(child_obj, parent_obj, parent_folder_path, export_child)
+def _project_info():
+    project = scriptengine.projects.primary
+    project_path = get_project_path(project)
+    project_name = os.path.splitext(os.path.basename(project_path))[0]
+    return project_path, project_name
 
 
 try:
     print_python_version()
     assert_project_open()
 
-    src_folder = get_src_folder(scriptengine.projects.primary)
-    print("Writing to: " + src_folder)
+    project_path, project_name = _project_info()
+    out_dir = get_export_target(project_path, project_name, sys.argv)
+    print("Writing to: " + out_dir)
 
-    if os.path.exists(src_folder):
-        shutil.rmtree(src_folder)
-    os.mkdir(src_folder)
+    if os.path.exists(out_dir):
+        print("Removing existing: " + out_dir)
+        try:
+            shutil.rmtree(out_dir)
+        except Exception as ex:
+            print("WARN: could not remove existing dir '{}': {}".format(out_dir, ex))
+            raise
+    os.makedirs(out_dir)
 
     for device_obj in get_device_entrypoints(scriptengine.projects.primary):
-        device_folder = os.path.join(src_folder, device_obj.get_name())
+        device_folder = os.path.join(out_dir, safe_filename(device_obj.get_name()))
         os.mkdir(device_folder)
+        register_directory(out_dir, os.path.basename(device_folder), device_obj.get_name())
 
         application = find_application(device_obj)
         application_folder = os.path.join(device_folder, "application")
         os.mkdir(application_folder)
+        register_directory(device_folder, "application", application.get_name())
 
         for child_obj in application.get_children():
             export_child(child_obj, application, application_folder)
 
         communication = find_communication(device_obj)
         export_communication(communication, device_folder)
+
 except Exception as e:
     print(e)
-    raise e
+    print(
+        "HINT: If you see [Errno 13] access denied, close editors/Explorer/OneDrive locking the export folder or export to a different path via argv."
+    )
+    raise
 
 print("Done!")

--- a/src/script_import_from_files.py
+++ b/src/script_import_from_files.py
@@ -1,14 +1,24 @@
 # REMEMBER: this is python 2.7
 from __future__ import print_function
 
+import os
+import sys
+
 import scriptengine  # type: ignore
 
 from import_from_files import import_from_files
-from util import *
+from entrypoint import get_import_source, get_project_path
+from util import assert_project_open, print_python_version
 
 try:
     print_python_version()
     assert_project_open()
+
+    project = scriptengine.projects.primary
+    project_path = get_project_path(project)
+    project_name = os.path.splitext(os.path.basename(project_path))[0]
+    src_dir = get_import_source(project_path, project_name, sys.argv)
+    print("Importing from: " + src_dir)
 
     ui_continue = scriptengine.system.ui.prompt(
         "Import From Files will overwrite unexported changes in the current project!\n\nDo you want to continue?",
@@ -19,9 +29,10 @@ try:
     )
 
     if ui_continue == scriptengine.PromptResult.Yes:
-        import_from_files(scriptengine.projects.primary)
+        import_from_files(project, src_dir)
 except Exception as e:
     print(e)
-    raise e
+    print("HINT: Pass a custom source folder via argv[1] to avoid locked or missing files.")
+    raise
 
 print("Done!")

--- a/src/util.py
+++ b/src/util.py
@@ -1,10 +1,154 @@
+# -*- coding: utf-8 -*-
 # REMEMBER: this is python 2.7
+import io
+import json
 import os
+import re
 import sys
+
+try:
+    import unicodedata
+except Exception:
+    unicodedata = None
 
 import scriptengine  # type: ignore
 
 from object_type import get_object_type
+
+SMART_MAP = {
+    u"\u2013": u"-",  # en dash
+    u"\u2014": u"-",  # em dash
+    u"\u2018": u"'",  # left single quote
+    u"\u2019": u"'",  # right single quote
+    u"\u201c": u'"',  # left double quote
+    u"\u201d": u'"',  # right double quote
+    u"\xa0": u" ",  # non-breaking space
+}
+
+_NAMES_FILE = "_names.json"
+_NAMES_CACHE = {}
+
+
+def _to_u(s):
+    try:
+        return s if isinstance(s, unicode) else unicode(s, "utf-8", "ignore")
+    except NameError:
+        return s
+
+
+def sanitize_text(s):
+    u = _to_u(s)
+    for k, v in SMART_MAP.items():
+        u = u.replace(k, v)
+    return u
+
+
+def safe_filename(name):
+    u = sanitize_text(name)
+    if unicodedata:
+        u = unicodedata.normalize("NFKD", u)
+    try:
+        u = u.encode("ascii", "ignore").decode("ascii")
+    except Exception:
+        pass
+    u = re.sub(r"[^\w\-. ]+", "_", u)
+    u = u.strip().rstrip(".")
+    return u or "unnamed"
+
+
+def ensure_dir(directory):
+    if directory and not os.path.isdir(directory):
+        os.makedirs(directory)
+
+
+def _names_meta_path(directory):
+    return os.path.join(directory, _NAMES_FILE)
+
+
+def _load_names(directory):
+    if directory in _NAMES_CACHE:
+        return _NAMES_CACHE[directory]
+    meta_path = _names_meta_path(directory)
+    if not directory or not os.path.exists(meta_path):
+        data = {}
+    else:
+        try:
+            with io.open(meta_path, "r", encoding="utf-8") as meta_file:
+                content = meta_file.read()
+                data = json.loads(content) if content else {}
+        except Exception:
+            data = {}
+    _NAMES_CACHE[directory] = data
+    return data
+
+
+def register_original_name(directory, safe_key, original_name, parent_name=None, kind=None):
+    if not directory or not safe_key or not original_name:
+        return
+    entry = {"name": original_name}
+    if parent_name:
+        entry["parent"] = parent_name
+    if kind:
+        entry["kind"] = kind
+    names = _load_names(directory)
+    if names.get(safe_key) == entry:
+        return
+    names[safe_key] = entry
+    ensure_dir(directory)
+    meta_path = _names_meta_path(directory)
+    with io.open(meta_path, "w", encoding="utf-8") as meta_file:
+        json.dump(names, meta_file, ensure_ascii=False, indent=2, sort_keys=True)
+        meta_file.write(u"\n")
+
+
+def get_original_entry(directory, safe_key):
+    if not directory or not safe_key:
+        return None
+    names = _load_names(directory)
+    return names.get(safe_key)
+
+
+def resolve_original_name(directory, safe_key, default=None):
+    entry = get_original_entry(directory, safe_key)
+    if entry and entry.get("name"):
+        return entry["name"]
+    if default is not None:
+        return default
+    return safe_key
+
+
+def find_safe_name(directory, original_name, kind=None, parent_name=None):
+    if not directory or not original_name:
+        return None
+    names = _load_names(directory)
+    for safe_key, entry in names.items():
+        if entry.get("name") != original_name:
+            continue
+        if kind and entry.get("kind") != kind:
+            continue
+        if parent_name and entry.get("parent") != parent_name:
+            continue
+        return safe_key
+    return None
+
+
+def write_file(path, text, original_name=None, parent_name=None):
+    """UTF-8 writer with newline normalization + sanitization."""
+    ensure_dir(os.path.dirname(path))
+    with io.open(path, "w", encoding="utf-8", newline=u"\n") as f:
+        f.write(sanitize_text(_to_u(text)))
+    if original_name:
+        register_original_name(
+            os.path.dirname(path),
+            os.path.basename(path),
+            original_name,
+            parent_name=parent_name,
+            kind="file",
+        )
+
+
+def register_directory(parent_directory, safe_name, original_name):
+    register_original_name(parent_directory, safe_name, original_name, kind="dir")
 
 
 def print_python_version():


### PR DESCRIPTION
## Purpose
- stop scii codec crashes when exporting IEC objects containing smart punctuation
- keep generated filenames filesystem-safe while preserving the original IEC names for round-trips
- let ScriptEngine users point export/import runs at custom folders to avoid locks while projects stay open

## Context
- ScriptEngine runs on Python 2.7 and choked on smart quotes, dashes, and NBSP characters in customer projects
- Windows users frequently hit access denied errors when exporting into the project directory because the IDE keeps files locked

## Implementation
- expanded src/util.py with sanitisation helpers, safe filename generation, UTF-8 writers, and _names.json bookkeeping so we can map safe filenames back to IEC object names
- refactored src/import_export.py and communication helpers to call the new utilities, register every exported file/folder, and resolve the original names when importing back into CODESYS
- updated the entrypoint and ScriptEngine wrappers to detect project paths, honour sys.argv[1] overrides, and print actionable hints when cleanup fails or files are locked
- documented the workflow in README.md and captured the implementation brief/test plan in Plan.md

## Testing
- Not run here (ScriptEngine/CODESYS environment not available in this CLI). Manual regression passes required per Plan.md once run inside CODESYS.

## Deployment Notes
- Export runs now drop a _names.json file alongside generated assets; keep it with the export so imports can restore the original IEC names.