### PR TITLE
Add archived warning: maintenance moving to nineyards-robotics

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+> [!WARNING]
+> **This repository has been archived.** `codescribe` has moved to a new home at **[nineyards-robotics/codescribe](https://github.com/nineyards-robotics/codescribe)**.
+> You can find it here: https://github.com/nineyards-robotics/codescribe
+
 # CODESCRIBE
 
 _/koh-DEH-skribe/_


### PR DESCRIPTION
I'm proposing we archive this repository and point users to the new home at https://github.com/nineyards-robotics/codescribe.

I'd like to continue maintaining it under nineyards-robotics - an open-source org I've set up as a centralised place for a bunch of robotics tooling. Having it under an org rather than a personal account means I can bring in other collaborators more easily.

 This PR adds a warning banner to the README pointing to the new repo. After merging, I'd suggest archiving the repo so it's clear this is no longer the active home.

The new repo retains the Apache 2.0 license and includes a NOTICE file with full attribution to GreenForge Labs.