### PR TITLE
Export Actions/Transitions as .st, fix non-ASCII export, make Communication optional

### DIFF
--- a/src/entrypoint.py
+++ b/src/entrypoint.py
@@ -31,6 +31,6 @@ def find_application(device_obj):
 
 
 def find_communication(device_obj):
-    # Not every device has a Communication object — depends on the device package.
+    # Not every device has a Communication object - depends on the device package.
     # Callers must treat None as "skip the communication step".
     return first_or_none(device_obj.find("Communication", recursive=True))

--- a/src/entrypoint.py
+++ b/src/entrypoint.py
@@ -31,7 +31,6 @@ def find_application(device_obj):
 
 
 def find_communication(device_obj):
-    return first_or_error(
-        device_obj.find("Communication", recursive=True),
-        "Couldn't find Communication inside " + device_obj.get_name(),
-    )
+    # Not every device has a Communication object — depends on the device package.
+    # Callers must treat None as "skip the communication step".
+    return first_or_none(device_obj.find("Communication", recursive=True))

--- a/src/import_export.py
+++ b/src/import_export.py
@@ -2,6 +2,8 @@
 import os
 import re
 
+import scriptengine  # type: ignore
+
 from object_type import ObjectType, get_object_type
 from util import *
 
@@ -202,6 +204,64 @@ def import_method_st(child, dir_path, dir_parent_obj, import_dir_fn):
         import_st(f, method_obj)
 
 
+def _export_member_st_or_xml(child_obj, parent_obj, parent_folder_path, st_suffix):
+    # Actions and Transitions have no textual declaration - the on-disk format is the
+    # implementation text alone, with the kind encoded in the filename (.action.st / .transition.st)
+    # so import dispatch is deterministic.
+    base = os.path.join(parent_folder_path, parent_obj.get_name() + "." + child_obj.get_name())
+    if child_obj.has_textual_implementation:
+        with open_utf8(base + st_suffix + ".st", "w") as f:
+            f.write(child_obj.textual_implementation.text)
+    else:
+        write_native(child_obj, base + ".xml", recursive=False)
+
+
+def export_action(child_obj, parent_obj, parent_folder_path, export_child_fn):
+    _export_member_st_or_xml(child_obj, parent_obj, parent_folder_path, ".action")
+
+
+def export_transition(child_obj, parent_obj, parent_folder_path, export_child_fn):
+    _export_member_st_or_xml(child_obj, parent_obj, parent_folder_path, ".transition")
+
+
+def _import_member_st(child, dir_path, dir_parent_obj, st_suffix, create_fn):
+    full_path = os.path.join(dir_path, child)
+    filename, _ = os.path.splitext(child)
+    filename = filename[: -len(st_suffix)]
+    parent_name, child_name = filename.split(".")
+    parent_obj = first_of_type_or_error(
+        dir_parent_obj.find(parent_name),
+        ObjectType.POU,
+        parent_name + " should have been created, but cannot be found",
+    )
+
+    new_obj = create_fn(parent_obj, child_name)
+    with open_utf8(full_path, "r") as f:
+        new_obj.textual_implementation.replace(f.read().strip() + u"\n")
+
+
+def import_action_st(child, dir_path, dir_parent_obj, import_dir_fn):
+    # Pass the ST language explicitly: unlike methods, actions have no declaration line
+    # for CODESYS to infer the language from.
+    _import_member_st(
+        child,
+        dir_path,
+        dir_parent_obj,
+        ".action",
+        lambda parent, name: parent.create_action(name, scriptengine.ImplementationLanguages.st),
+    )
+
+
+def import_transition_st(child, dir_path, dir_parent_obj, import_dir_fn):
+    _import_member_st(
+        child,
+        dir_path,
+        dir_parent_obj,
+        ".transition",
+        lambda parent, name: parent.create_transition(name, scriptengine.ImplementationLanguages.st),
+    )
+
+
 def export_sub_pou(child_obj, parent_obj, parent_folder_path, export_child_fn):
     write_native(
         child_obj,
@@ -233,8 +293,8 @@ OBJECT_TYPE_TO_EXPORT_FUNCTION = {
     ObjectType.DUT: export_dut,
     ObjectType.METHOD: export_method,
     ObjectType.PROPERTY: export_sub_pou,
-    ObjectType.ACTION: export_sub_pou,
-    ObjectType.TRANSITION: export_sub_pou,
+    ObjectType.ACTION: export_action,
+    ObjectType.TRANSITION: export_transition,
 }
 
 

--- a/src/import_export.py
+++ b/src/import_export.py
@@ -5,8 +5,9 @@ import re
 from object_type import ObjectType, get_object_type
 from util import *
 
-IMPLEMENTATION_DELIMITER_SPLIT = "// --- BEGIN IMPLEMENTATION ---"
-IMPLEMENTATION_DELIMITER_INSERT = "\n" + IMPLEMENTATION_DELIMITER_SPLIT + "\n\n"
+# unicode literals so they can be written to / split out of the UTF-8 text streams below
+IMPLEMENTATION_DELIMITER_SPLIT = u"// --- BEGIN IMPLEMENTATION ---"
+IMPLEMENTATION_DELIMITER_INSERT = u"\n" + IMPLEMENTATION_DELIMITER_SPLIT + u"\n\n"
 
 
 def write_st(obj, f):
@@ -21,7 +22,7 @@ def write_st_decl_only(obj, f):
 
 def import_st(f, obj):
     f.seek(0)
-    content = str(f.read())
+    content = f.read()
     declaration, implementation = content.split(IMPLEMENTATION_DELIMITER_SPLIT)
     obj.textual_declaration.replace(declaration.strip() + "\n")
     obj.textual_implementation.replace(implementation.strip() + "\n")
@@ -29,7 +30,7 @@ def import_st(f, obj):
 
 def import_st_decl_only(f, obj):
     f.seek(0)
-    content = str(f.read())
+    content = f.read()
     obj.textual_declaration.replace(content.strip() + "\n")
 
 
@@ -94,7 +95,7 @@ def import_folder(child, dir_path, dir_parent_obj, import_dir_fn):
 
 def export_pou(child_obj, parent_obj, parent_folder_path, export_child_fn):
     if child_obj.has_textual_implementation:
-        with open(os.path.join(parent_folder_path, child_obj.get_name() + ".st"), "w") as f:
+        with open_utf8(os.path.join(parent_folder_path, child_obj.get_name() + ".st"), "w") as f:
             write_st(child_obj, f)
     else:
         export_native(child_obj, parent_obj, parent_folder_path, export_child_fn)
@@ -106,7 +107,7 @@ def export_pou(child_obj, parent_obj, parent_folder_path, export_child_fn):
 def import_pou_st(child, dir_path, dir_parent_obj, import_dir_fn):
     filename, _ = os.path.splitext(child)
     pou_obj = dir_parent_obj.create_pou(filename)
-    with open(os.path.join(dir_path, child), "r") as f:
+    with open_utf8(os.path.join(dir_path, child), "r") as f:
         import_st(f, pou_obj)
 
 
@@ -116,7 +117,7 @@ def export_gvl(child_obj, parent_obj, parent_folder_path, export_child_fn):
     This is because we need to support EVL and NVL as well, using this function.
     """
     write_native(child_obj, os.path.join(parent_folder_path, child_obj.get_name() + ".gvl.xml"), recursive=False)
-    with open(os.path.join(parent_folder_path, child_obj.get_name() + ".gvl.st"), "w") as f:
+    with open_utf8(os.path.join(parent_folder_path, child_obj.get_name() + ".gvl.st"), "w") as f:
         write_st_decl_only(child_obj, f)
 
 
@@ -143,7 +144,7 @@ def import_gvl(child, dir_path, dir_parent_obj, import_dir_fn):
     else:
         imported_obj = dir_parent_obj.create_gvl(name)
 
-    with open(os.path.join(dir_path, child), "r") as f:
+    with open_utf8(os.path.join(dir_path, child), "r") as f:
         import_st_decl_only(f, imported_obj)
 
 
@@ -160,21 +161,21 @@ def import_native(child, dir_path, dir_parent_obj, import_dir_fn):
 
 
 def export_dut(child_obj, parent_obj, parent_folder_path, export_child_fn):
-    with open(os.path.join(parent_folder_path, child_obj.get_name() + ".st"), "w") as f:
+    with open_utf8(os.path.join(parent_folder_path, child_obj.get_name() + ".st"), "w") as f:
         f.write(child_obj.textual_declaration.text)
 
 
 def import_dut(child, dir_path, dir_parent_obj, import_dir_fn):
     filename, _ = os.path.splitext(child)
     dut_obj = dir_parent_obj.create_dut(filename)
-    with open(os.path.join(dir_path, child), "r") as f:
+    with open_utf8(os.path.join(dir_path, child), "r") as f:
         f.seek(0)
-        dut_obj.textual_declaration.replace(str(f.read()))
+        dut_obj.textual_declaration.replace(f.read())
 
 
 def export_method(child_obj, parent_obj, parent_folder_path, export_child_fn):
     if child_obj.has_textual_implementation:
-        with open(
+        with open_utf8(
             os.path.join(parent_folder_path, parent_obj.get_name() + "." + child_obj.get_name() + ".st"), "w"
         ) as f:
             write_st(child_obj, f)
@@ -197,7 +198,7 @@ def import_method_st(child, dir_path, dir_parent_obj, import_dir_fn):
     )
 
     method_obj = parent_obj.create_method(method_name)
-    with open(full_path, "r") as f:
+    with open_utf8(full_path, "r") as f:
         import_st(f, method_obj)
 
 

--- a/src/import_from_files.py
+++ b/src/import_from_files.py
@@ -34,12 +34,18 @@ def import_directory_child(child, dir_path, dir_parent_obj):
         if ext == ".st":
             import_gvl(child, dir_path, dir_parent_obj, import_directory)
     elif "." in filename:
-        # . means some sort of sub POU
+        # . means some sort of sub POU (method, action, transition, property)
         if ext == ".xml":
             import_sub_pou(child, dir_path, dir_parent_obj, import_directory)
         if ext == ".st":
-            # currently only methods are exported as ST if possible
-            import_method_st(child, dir_path, dir_parent_obj, import_directory)
+            # Filename suffix selects the sub-POU kind. "action" / "transition" are
+            # reserved IEC keywords so they can't collide with a method name.
+            if filename.endswith(".action"):
+                import_action_st(child, dir_path, dir_parent_obj, import_directory)
+            elif filename.endswith(".transition"):
+                import_transition_st(child, dir_path, dir_parent_obj, import_directory)
+            else:
+                import_method_st(child, dir_path, dir_parent_obj, import_directory)
     else:
         if ext == ".xml":
             import_native(child, dir_path, dir_parent_obj, import_directory)

--- a/src/import_from_files.py
+++ b/src/import_from_files.py
@@ -50,14 +50,25 @@ def import_directory_child(child, dir_path, dir_parent_obj):
         if ext == ".xml":
             import_native(child, dir_path, dir_parent_obj, import_directory)
         if ext == ".st":
-            # Have to check for keywords to determine if POU or DUT
+            # Have to check for keywords to determine if POU or DUT.
+            # Finish (close) this read before dispatching: the import functions re-open
+            # the same file, and IronPython's io.open holds a .NET file lock that makes
+            # a nested open of an already-open file fail with a sharing violation.
+            kind = None
             with open_utf8(full_path, "r") as f:
                 for word in first_word_of_line_iter(f):
                     if word == "TYPE":
-                        import_dut(child, dir_path, dir_parent_obj, import_directory)
+                        kind = "dut"
+                        break
 
                     if word in ["PROGRAM", "FUNCTION_BLOCK", "FUNCTION"]:
-                        import_pou_st(child, dir_path, dir_parent_obj, import_directory)
+                        kind = "pou"
+                        break
+
+            if kind == "dut":
+                import_dut(child, dir_path, dir_parent_obj, import_directory)
+            elif kind == "pou":
+                import_pou_st(child, dir_path, dir_parent_obj, import_directory)
 
 
 def import_from_files(project):

--- a/src/import_from_files.py
+++ b/src/import_from_files.py
@@ -45,7 +45,7 @@ def import_directory_child(child, dir_path, dir_parent_obj):
             import_native(child, dir_path, dir_parent_obj, import_directory)
         if ext == ".st":
             # Have to check for keywords to determine if POU or DUT
-            with open(full_path, "r") as f:
+            with open_utf8(full_path, "r") as f:
                 for word in first_word_of_line_iter(f):
                     if word == "TYPE":
                         import_dut(child, dir_path, dir_parent_obj, import_directory)

--- a/src/import_from_files.py
+++ b/src/import_from_files.py
@@ -69,4 +69,5 @@ def import_from_files(project):
         import_directory(application_folder, application)
 
         communication = find_communication(device_obj)
-        import_communication(communication, device_folder)
+        if communication is not None:
+            import_communication(communication, device_folder)

--- a/src/script_export_to_files.py
+++ b/src/script_export_to_files.py
@@ -43,7 +43,8 @@ try:
             export_child(child_obj, application, application_folder)
 
         communication = find_communication(device_obj)
-        export_communication(communication, device_folder)
+        if communication is not None:
+            export_communication(communication, device_folder)
 except Exception as e:
     print(e)
     raise e

--- a/src/script_export_to_files.py
+++ b/src/script_export_to_files.py
@@ -47,6 +47,8 @@ try:
             export_communication(communication, device_folder)
 except Exception as e:
     print(e)
+    ui_error_with_traceback("Export To Files failed!")
     raise e
 
 print("Done!")
+ui_info("Export To Files complete.\n\nWrote: " + src_folder)

--- a/src/script_import_from_files.py
+++ b/src/script_import_from_files.py
@@ -20,8 +20,12 @@ try:
 
     if ui_continue == scriptengine.PromptResult.Yes:
         import_from_files(scriptengine.projects.primary)
+        ui_info("Import From Files complete.")
+    else:
+        print("Import cancelled.")
 except Exception as e:
     print(e)
+    ui_error_with_traceback("Import From Files failed!")
     raise e
 
 print("Done!")

--- a/src/script_save_as_template.py
+++ b/src/script_save_as_template.py
@@ -59,6 +59,8 @@ try:
         delete_old_templates(template_paths)
 except Exception as e:
     print(e)
+    ui_error_with_traceback("Save As Template failed!")
     raise e
 
 print("Done!")
+ui_info("Save As Template complete.\n\nCreated: " + new_template_path)

--- a/src/script_save_as_template.py
+++ b/src/script_save_as_template.py
@@ -50,7 +50,8 @@ try:
         application = find_application(device_obj)
         remove_tracked_objects(application.get_children())
         communication = find_communication(device_obj)
-        remove_tracked_communication_devices(communication)
+        if communication is not None:
+            remove_tracked_communication_devices(communication)
 
     template_project.save()
 

--- a/src/script_update_from_template.py
+++ b/src/script_update_from_template.py
@@ -44,8 +44,12 @@ try:
         import_from_files(scriptengine.projects.primary)
 
         scriptengine.projects.primary.save()
+        ui_info("Update From Template complete.")
+    else:
+        print("Update cancelled.")
 except Exception as e:
     print(e)
+    ui_error_with_traceback("Update From Template failed!")
     raise e
 
 print("Done!")

--- a/src/util.py
+++ b/src/util.py
@@ -2,10 +2,21 @@
 import io
 import os
 import sys
+import traceback
 
 import scriptengine  # type: ignore
 
 from object_type import get_object_type
+
+
+def ui_info(message):
+    # Blocking dialog; the message view is easy to miss, so entry scripts report
+    # their outcome through these as well.
+    scriptengine.system.ui.info(message)
+
+
+def ui_error_with_traceback(message):
+    scriptengine.system.ui.error(message + "\n\n" + traceback.format_exc())
 
 
 def open_utf8(path, mode):

--- a/src/util.py
+++ b/src/util.py
@@ -1,10 +1,18 @@
 # REMEMBER: this is python 2.7
+import io
 import os
 import sys
 
 import scriptengine  # type: ignore
 
 from object_type import get_object_type
+
+
+def open_utf8(path, mode):
+    # ScriptEngine runs on Python 2.7; the builtin open() writes a byte stream and would
+    # implicitly encode unicode text as ascii, crashing on Cyrillic / accented chars / smart
+    # punctuation. io.open with an explicit encoding keeps everything UTF-8 round-trippable.
+    return io.open(path, mode, encoding="utf-8")
 
 
 def print_python_version():


### PR DESCRIPTION
Three fixes, validated on CODESYS V3.5 SP11 (32-bit) and an IFM CR711S (compound Standard + SIL2 project):

- **#17:** changed so now all `.st` reads/writes routed through `io.open(..., encoding="utf-8")`. Non-ASCII content (Cyrillic, accents, smart punctuation) now exports and round-trips. ASCII-only exports verified byte-identical to the previous release.
- **#19:** Actions and Transitions export as plaintext `.st` (implementation only, kind encoded in the filename). Import recreates them via `create_action`/`create_transition` with the language passed explicitly. Round-trip and F11 verified, plus runtime checks in simulation and on hardware.
- `find_communication` returns `None` instead of raising when a device has no Communication object; all three callers (export, import, Save-as-Template) guard it.

Two additional bugs were found and fixed during live validation: an em-dash in a comment violating IronPython's PEP 263 ASCII-source rule, and a nested `io.open` of the same file causing a sharing violation on every import. Entry scripts also now report success/failure via blocking dialogs (failure includes the full traceback).